### PR TITLE
Add milestone reward validation to prevent excessive rewards

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,14 +16,14 @@ A blockchain-based platform for tracking career development goals and mentor mat
 - Progress tracking 
 - Milestone creation and completion validation
 - Reputation system for mentors and mentees
-- Milestone-based rewards system
+- Milestone-based rewards system with validation
 - User rewards balance management
 
 ## Milestone System
 Users can now:
 - Create milestones for their goals with reward amounts
 - Track milestone completion progress
-- Earn rewards for completing milestones
+- Earn rewards for completing milestones (max 10,000 per milestone)
 - Accumulate rewards in their user profile
 
-The milestone system provides additional motivation and structure for achieving career development goals.
+The milestone system provides additional motivation and structure for achieving career development goals while maintaining reasonable reward limits.


### PR DESCRIPTION
This enhancement adds validation to milestone reward amounts to prevent potential abuse of the rewards system.

Changes made:
- Added a new error constant `err-invalid-milestone`
- Created a private function `validate-reward-amount` to check reward amounts
- Modified the `add-milestone` function to validate rewards before creation
- Added a maximum reward limit of 10,000 per milestone
- Added new test case to verify reward validation
- Updated documentation to reflect the reward limits

The changes improve the contract's security by preventing users from creating milestones with unreasonably high rewards. The limit of 10,000 per milestone provides sufficient flexibility while maintaining system integrity.

Testing:
- All existing tests pass
- New test case added to verify reward validation
- Manually tested with various reward amounts

Impact:
- No breaking changes to existing functionality
- Adds additional security layer to milestone creation
- Maintains backward compatibility